### PR TITLE
bumping package versions with update of ttm-coffeescript-math

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "javascript-calculator",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "dependencies": {
     "jquery": "~1.10.2",
     "underscore": "~1.5.2",
     "ttm-coffeescript-utilities": "git@github.com:thinkthroughmath/ttm-coffeescript-utilities.git#~0.0.1",
-    "ttm-coffeescript-math": "git@github.com:thinkthroughmath/ttm-coffeescript-math.git#0.3.1",
+    "ttm-coffeescript-math": "git@github.com:thinkthroughmath/ttm-coffeescript-math.git#0.3.2",
     "jasmine-jquery": "~1.5.1"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-calculator",
-  "version": "0.4.11",
+  "version": "0.4.13",
   "description": "Think Through Math Mathematics Widgets",
   "homepage": "https://github.com/thinkthroughmath/javascript-calculator",
   "dependencies": {

--- a/spec/calculator_spec.coffee
+++ b/spec/calculator_spec.coffee
@@ -86,6 +86,10 @@ describe "Calculator Widget features", ->
     @handle.press_buttons("1 0 square =")
     expect(@handle.output_content()).toEqual("100")
 
+  it "crashes on roots followed by another operation", ->
+    @handle.press_buttons("9 root + 1 =")
+    expect(@handle.output_content()).toEqual("4")
+
   it "will negate a nuber that is already entered" , ->
     @handle.press_buttons("1 1 negative")
     expect(@handle.output_content()).toEqual("-11")


### PR DESCRIPTION
### What am I?
Test to verify feature bug from ttm-coffeescript-math

Version increases to include the updates from https://github.com/thinkthroughmath/ttm-coffeescript-math/pull/7

WIP until https://github.com/thinkthroughmath/ttm-coffeescript-math/pull/7

This will fail until https://github.com/thinkthroughmath/ttm-coffeescript-math/pull/7

### After merge
create a release for 0.4.13